### PR TITLE
UwcWindowUtil patch code

### DIFF
--- a/Assets/uWindowCapture/Scripts/UwcLib.cs
+++ b/Assets/uWindowCapture/Scripts/UwcLib.cs
@@ -194,6 +194,10 @@ public static class Lib
     public static extern int GetCursorHeight();
     [DllImport(name, EntryPoint = "UwcSetCursorTexturePtr")]
     public static extern void SetCursorTexturePtr(IntPtr ptr);
+    [DllImport(name, EntryPoint = "UwcGetScreenX")]
+    public static extern int GetScreenX();
+    [DllImport(name, EntryPoint = "UwcGetScreenY")]
+    public static extern int GetScreenY();
     [DllImport(name, EntryPoint = "UwcGetScreenWidth")]
     public static extern int GetScreenWidth();
     [DllImport(name, EntryPoint = "UwcGetScreenHeight")]

--- a/Assets/uWindowCapture/Scripts/UwcWindowUtil.cs
+++ b/Assets/uWindowCapture/Scripts/UwcWindowUtil.cs
@@ -7,12 +7,22 @@ public static class UwcWindowUtil
 {
     public static Vector3 ConvertDesktopCoordToUnityPosition(int x, int y, int width, int height, float basePixel)
     {
-        var w = width / basePixel;
-        var h = height / basePixel;
-        var l = x / basePixel;
-        var t = y / basePixel;
-        var unityX = (l + w / 2);
-        var unityY = (Screen.height / basePixel) - (t + h / 2);
+        var w = width;
+        var h = height;
+        var l = x;
+        var t = y;
+        var cx = l + w / 2;
+        var cy = t + h / 2;
+
+        var sw = Lib.GetScreenWidth();
+        var sh = Lib.GetScreenHeight();
+        var sl = Lib.GetScreenX();
+        var st = Lib.GetScreenY();
+        var sCX = sl + sw / 2;
+        var sCY = st + sh / 2;
+
+        var unityX = (cx - sCX) / basePixel;
+        var unityY = (-cy + sCY) / basePixel;
         return new Vector3(unityX, unityY, 0f);
     }
 

--- a/Plugins/uWindowCapture/uWindowCapture/Main.cpp
+++ b/Plugins/uWindowCapture/uWindowCapture/Main.cpp
@@ -616,6 +616,16 @@ extern "C"
         return;
     }
 
+    UNITY_INTERFACE_EXPORT UINT UNITY_INTERFACE_API UwcGetScreenX()
+    {
+        return ::GetSystemMetrics(SM_XVIRTUALSCREEN);
+    }
+
+    UNITY_INTERFACE_EXPORT UINT UNITY_INTERFACE_API UwcGetScreenY()
+    {
+        return ::GetSystemMetrics(SM_YVIRTUALSCREEN);
+    }
+
     UNITY_INTERFACE_EXPORT UINT UNITY_INTERFACE_API UwcGetScreenWidth()
     {
         return ::GetSystemMetrics(SM_CXVIRTUALSCREEN);


### PR DESCRIPTION
Hello hecomi.
This is a patch that fixes some bugs in UwcWindowUtil class and lets UwcDesktopLayouter places windows such that a position of windows' parent node matches a center of whole screens.

Reasons:
1. The existing UwcWindowUtil.ConvertDesktopCoordToUnityPosition() only aligns each window center in the Y-direction, but doesn't align center in the X-direction.
2. It is incorrect to use Screen.height in the calculating the value of unityY in UwcWindowUtil.ConvertDesktopCoordToUnityPosition(). Should use the height of the entire desktop instead of the height of the destination screen.