### PR TITLE
Don't hold a reference to a GraphicsCaptureItem when not capturing

### DIFF
--- a/Plugins/uWindowCapture/uWindowCapture/Window.cpp
+++ b/Plugins/uWindowCapture/uWindowCapture/Window.cpp
@@ -365,14 +365,16 @@ void Window::UpdateTitle()
         {
             if (const auto wgc = windowTexture_->GetWindowsGraphicsCapture())
             {
-                data2_.title = wgc->GetDisplayName();
+                if (wgc->IsStarted())
+                {
+                    data2_.title = wgc->GetDisplayName();
+                    return;
+                }
             }
         }
-        else
-        {
-            constexpr UINT timeout = 100 /* milliseconds */;
-            GetWindowTitle(data1_.hWnd, data2_.title, timeout);
-        }
+
+        constexpr UINT timeout = 100 /* milliseconds */;
+        GetWindowTitle(data1_.hWnd, data2_.title, timeout);
     }
     else
     {

--- a/Plugins/uWindowCapture/uWindowCapture/WindowTexture.cpp
+++ b/Plugins/uWindowCapture/uWindowCapture/WindowTexture.cpp
@@ -702,5 +702,5 @@ bool WindowTexture::GetPixels(BYTE* output, int x, int y, int width, int height)
 bool WindowTexture::IsWindowsGraphicsCaptureAvailable() const
 {
     auto wgc = windowsGraphicsCapture_.lock();
-    return wgc && wgc->IsAvailable();
+    return wgc != nullptr;
 }

--- a/Plugins/uWindowCapture/uWindowCapture/WindowsGraphicsCapture.cpp
+++ b/Plugins/uWindowCapture/uWindowCapture/WindowsGraphicsCapture.cpp
@@ -117,7 +117,6 @@ WindowsGraphicsCapture::WindowsGraphicsCapture(HWND hWnd)
     : hWnd_(hWnd)
     , hMonitor_(NULL)
 {
-    CreateItem();
 }
 
 
@@ -125,7 +124,6 @@ WindowsGraphicsCapture::WindowsGraphicsCapture(HMONITOR hMonitor)
     : hMonitor_(hMonitor)
     , hWnd_(NULL)
 {
-    CreateItem();
 }
 
 
@@ -235,10 +233,13 @@ void WindowsGraphicsCapture::Start()
 
     if (isStarted_) return;
 
-    if (CreatePoolAndSession())
+    if (CreateItem())
     {
-        isStarted_ = true;
-        restartTimer_ = 0.f;
+        if (CreatePoolAndSession())
+        {
+            isStarted_ = true;
+            restartTimer_ = 0.f;
+        }
     }
 }
 
@@ -251,6 +252,7 @@ void WindowsGraphicsCapture::Stop()
     isStarted_ = false;
 
     DestroyPoolAndSession();
+    item_ = nullptr;
 }
 
 
@@ -275,14 +277,6 @@ void WindowsGraphicsCapture::Restart()
     Stop();
     if (!CreateItem()) return;
     Start();
-}
-
-
-bool WindowsGraphicsCapture::IsAvailable() const
-{
-    std::scoped_lock lock(itemMutex_);
-
-    return item_ != nullptr;
 }
 
 
@@ -442,7 +436,6 @@ IDirect3DDevice & WindowsGraphicsCaptureManager::GetDevice()
 std::shared_ptr<WindowsGraphicsCapture> WindowsGraphicsCaptureManager::Create(HWND hWnd)
 {
     auto instance = std::make_shared<WindowsGraphicsCapture>(hWnd);
-    if (!instance->IsAvailable()) return nullptr;
 
     std::scoped_lock lock(allInstancesMutex_);
     allInstances_.push_back(instance);
@@ -454,7 +447,6 @@ std::shared_ptr<WindowsGraphicsCapture> WindowsGraphicsCaptureManager::Create(HW
 std::shared_ptr<WindowsGraphicsCapture> WindowsGraphicsCaptureManager::Create(HMONITOR hMonitor)
 {
     auto instance = std::make_shared<WindowsGraphicsCapture>(hMonitor);
-    if (!instance->IsAvailable()) return nullptr;
 
     std::scoped_lock lock(allInstancesMutex_);
     allInstances_.push_back(instance);

--- a/Plugins/uWindowCapture/uWindowCapture/WindowsGraphicsCapture.h
+++ b/Plugins/uWindowCapture/uWindowCapture/WindowsGraphicsCapture.h
@@ -36,7 +36,6 @@ public:
     int GetHeight() const { return size_.Height; }
     int GetWidth() const { return size_.Width; }
     void RequestStart();
-    bool IsAvailable() const;
     bool IsStarted() const { return isStarted_; }
     void EnableCursorCapture(bool enabled);
     Result TryGetLatestResult();


### PR DESCRIPTION
Only create the GraphicsCaptureItem just before we need to use the capture

This will allow the Windows Graphics Capture service to suspend itself when we are not capturing

This also gives the bonus effect of no longer having issues when the service dies while we aren't capturing (which would crash uWC without https://github.com/hecomi/uWindowCapture/pull/43

This did require a couple changes I would like you to review the impact of;
Removal of IsAvailable, as this relied on a persistent item_, this may affect any code that ensures capture is possible
Using GetWindowTitle() when a given item is not capturing
