### PR TITLE
fix dll doesn't compile issue

### DIFF
--- a/Plugins/uWindowCapture/uWindowCapture/uWindowCapture.def
+++ b/Plugins/uWindowCapture/uWindowCapture/uWindowCapture.def
@@ -1,0 +1,5 @@
+LIBRARY
+
+EXPORTS
+    UnityPluginLoad
+    UnityPluginUnload

--- a/Plugins/uWindowCapture/uWindowCapture/uWindowCapture.vcxproj
+++ b/Plugins/uWindowCapture/uWindowCapture/uWindowCapture.vcxproj
@@ -98,7 +98,7 @@
       <ModuleDefinitionFile>$(SolutionDir)$(ProjectName).def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\Assets\$(ProjectName)\Plugins\x86"</Command>
+      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\..\Assets\$(ProjectName)\Plugins\x86"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -110,7 +110,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
-      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\Assets\$(ProjectName)\Plugins\x86_64"</Command>
+      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\..\Assets\$(ProjectName)\Plugins\x86_64"</Command>
     </PostBuildEvent>
     <Link>
       <ModuleDefinitionFile>$(SolutionDir)$(ProjectName).def</ModuleDefinitionFile>
@@ -132,7 +132,7 @@
       <ModuleDefinitionFile>$(SolutionDir)$(ProjectName).def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\Assets\$(ProjectName)\Plugins\x86"</Command>
+      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\..\Assets\$(ProjectName)\Plugins\x86"</Command>
     </PostBuildEvent>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -154,7 +154,7 @@
       <ModuleDefinitionFile>$(SolutionDir)$(ProjectName).def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\Assets\$(ProjectName)\Plugins\x86_64"</Command>
+      <Command>copy /Y "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\..\..\Assets\$(ProjectName)\Plugins\x86_64"</Command>
     </PostBuildEvent>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>


### PR DESCRIPTION
I'm not sure if this is valid fix but at least I can't directly compile the C++ project out of the box. I have to do 2 things

1. copy the `.def` file into the project root directory
2. Edit the `.vcxproj` file and update the postbuild command path. The original path is not valid and it's missing one `\..`. 


After this change, i can compile successfully. However i'm not sure if this fix mess up anything else tho. Please check and let me know. Thanks!